### PR TITLE
Add method `trackEvent()` to main exports object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,3 +156,20 @@ exp.cxtOfEmission = function(emitter, event, fn) {
     fn(emDetails.getEventDetails(event).getEmissionCxt());
   }
 }
+
+/**
+* @api public
+* @param {EventEmitter} emitter
+* @param {String} event Event to track
+* @return {Object} evDetails
+*
+* Creates an EmitterDetails obj.  Registers the event. Returns instance of
+* EventDetails.  Intended use is when the listener for the event is irrelevant,
+* i.e., we only want to *quickly-n-easily* spy on the event to get stats on it.
+*/
+exp.trackEvent = function (emitter, event) {
+  var NOP = Object.getPrototypeOf(Function);
+
+  EE.prototype.on.call(emitter, event, NOP);
+  return exp(emitter).getEventDetails(event);
+};

--- a/test/index/main.js
+++ b/test/index/main.js
@@ -147,3 +147,14 @@ assert.ok(("event1" in d1.events));
     ["newListener", "removeListener", "event1", "event3"], Object.keys(d.events)
   );
 }());
+
+// trackEvent()
+(function () {
+  var e = new EE(), ev = "turn-on",
+      evDetails;
+
+  evDetails = getDetails.trackEvent(e, ev);
+  // make sure its strictEqual and not a copy so we are assured that the stats
+  // are updated live
+  assert.strictEqual(evDetails, evDetails._parent.events[ev]);
+})();


### PR DESCRIPTION
This method is meant to be for event emitters that don't have...
