### PR TITLE
Update README:  CRLF after 'Output'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ put(util.inspect(d, {
     }));
 
 ```
-Output:
+Output:<br/>
 ![Output of Script](./log-details-output.png)
 
 API


### PR DESCRIPTION
Adds a `<br/>` before the example img so it aligns to the left.
