### PR TITLE
lib, test, README: fix fake test of onUpdate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- Since I cannot figure out how to put anchor links, I have replaced it with
      simply embolding the name of the header.  TODO use anchor links -->
-     
+
 ![build status badge](https://travis-ci.org/reecehudson/node-emitter-details.svg)
 
 Node Emitter Details
@@ -127,7 +127,7 @@ When **exp** is:
 * `onUpdate(fn)`
   * `fn` callback, called next time there is an change of properties.  This
     happens when any of the events pertaining to the parent object are emitted.
-    Receives, two arguments: event, and event details object.
+    Event details instance is passed as the only arguments.
 
 #### Handler Details ####
 * `arity`

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function getEmitterDetails(emitter, opts) {
 
     if (util.isNull(evDetails = emitterDetails.getEventDetails(event))) {
       evDetails = emitterDetails._addEvent(event, listener);
-      // for @lib/event-details.js onUpdate()
+      // used in lib/event-details.js onUpdate()
       evDetails.genericEventRegulator = genericEventRegulator;
       evDetails.name = event;
       if (!(event === "newListener" || event === "removeListener"))

--- a/lib/event-details.js
+++ b/lib/event-details.js
@@ -111,7 +111,7 @@ EventDetails.prototype._removeHandler = function(fn) {
 
 /**
   * @api public
-  * @param {Function} fn Callback passed (eventName, eventDetails)
+  * @param {Function} fn Callback passed (eventDetails)
   * @return {undefined}
 */
 EventDetails.prototype.onUpdate = function (fn) {

--- a/test/event-details/onUpdate.js
+++ b/test/event-details/onUpdate.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var getDetails = require("../../");
+var assert = require("assert");
+
+// test asyn EventDetails.prototype.onUpdate()
+(function () {
+  var e, emD, ev1D, asyncEv1D, done = false;
+
+    process.on("exit", function () {
+      assert.ok(done);
+    });
+
+    e = createEmitter();
+    emD = getDetails(e);
+
+    e.on("event1", function noop () {});
+    ev1D = emD.getEventDetails("event1");
+    emD.getEventDetails("event1").onUpdate(function () {
+      assert.equal(arguments.length, 1, "unexpected args");
+      asyncEv1D = arguments[0];
+      assert.strictEqual(ev1D, asyncEv1D);
+      done = true;
+    });
+    e.emit("event1");
+})();
+
+function createEmitter () {
+  var E = require("events");
+  return new E(Object.create(null));
+}

--- a/test/index/main.js
+++ b/test/index/main.js
@@ -77,20 +77,6 @@ e1.removeListener("event1", event1Dummy2);
 // b/c opts:saveInactiveEventDetails is explicitly on in opts, we can assert
 assert.ok(("event1" in d1.events));
 
-// test asyn EventDetails.prototype.onUpdate()
-(function () {
-  var e, emD, ev1D, asyncEv1D;
-    e = createEmitter();
-    emD = getDetails(e);
-
-    e.on("event1", function noop () {});
-    ev1D = emD.getEventDetails("event1");
-    emD.getEventDetails("event1").onUpdate(function () {
-      asyncEv1D = arguments[0];
-      assert.strictEqual(ad, d);
-    });
-})();
-
 /* The nex part of this test consists of checking that the options work */
 
 // options :: saveInactiveEventDetails


### PR DESCRIPTION
This correctly tests `EventDetails.prototype.onUpdate()` which was originally
implemented in 2c8f7ef, we correctly do it by making sure we emit the event a
second time so `genericEventRegulator()` is invoked aka updated.  The current
test is replicated and exported to it's own proper test file.

This also corrects docs by saying the only arg passed to the cb.
