### PR TITLE
test, .travis.yml, package.json: new test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,4 @@ node_js:
     - "4.1"
     - "4.4.5"
 script:
-  - node test/stack-trace.js
-  - node test/common/objForEach.js
-  - node test/emitter-details/_addEvent.js
-  - node test/emitter-details/getEventDetails.js
-  - node test/event-details/_addHandler.js
-  - node test/event-details/_removeHandler.js
-  - node test/event-details/getHandlerDetails.js
-  - node test/event-details/getHandlers.js
-  - node test/event-details/getHandlersDetails.js
-  - node test/handler-details/HandlerDetails.js
-  - node test/index/main.js
-env:
-    - IS_TRAVIS_CI="true"
+  - npm run-script test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "test.bat"
+    "test": "node test/test.js"
   },
   "repository": {
     "type": "git",

--- a/test/stack-trace.js
+++ b/test/stack-trace.js
@@ -41,7 +41,7 @@ function tester2() {
   var s1, s2, s3, tstr, tlen;
 
   s1 = "    at tester2 ";
-  s2 = "(" +  process.cwd();
+  s2 = "(" +  __dirname;
   // NOTE we do not include 'test/' because that *should be* the CD as is
   // changed by test.bat
   s3 = path.sep + "stack-trace.js";

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,50 @@
+"use strict";
+// TODO use spawn() (async)
+
+var fs = require("fs");
+
+if (process.env.TESTING === "true") ; // skip
+else {
+  process.env.TESTING = "true";
+
+  // FIXME this is a bad comparison since you are using the same function to
+  // count files of acutal/expected
+  console.log(
+    "\n(%d of %d) tests ran",
+    countFilesDeep(__dirname, test),
+    countFilesDeep(__dirname)
+  );
+}
+
+function test(path) {
+  var spawnSync = require("child_process").spawnSync,
+      child;
+
+  console.log("running test: %s", path.split(/\\|\//).pop());
+  child = spawnSync("node", [path]);
+  child.stdout.length ? process.stdout.write(child.stdout, "buffer"): void(0);
+  child.stderr.length ? process.stdout.write(child.stderr, "buffer") : void(0);
+}
+
+// FIXME should this be part of helpers
+function countFilesDeep (dir, fn) {
+  var conts = fs.readdirSync(dir), tot = 0;
+
+  conts.forEach(function (item) {
+    item = fullPath(dir, item);
+    if (fs.statSync(item).isDirectory()) {
+        tot += countFilesDeep(item, fn);
+      } else {
+        tot += 1;
+        if (fn) fn(item);
+      }
+   }, null);
+
+   return tot;
+
+  function fullPath(dir, file) {
+    var path = require("path");
+
+    return dir + path.sep + file;
+  }
+ }


### PR DESCRIPTION
We implement a test scrip that replaces the former one.  Now all we do
is run `node test/test.js` and it traverses through the test/ dir and
executes via workers.

Also replaces process.cwd() widh `__dirname` because it should be relative
to the module and not the process.

Fixes:  #29
